### PR TITLE
add sample execution 1thread with stack and uint256

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.ptx
 *.cubin
 *.fatbin
+*.o

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,0 +1,16 @@
+{
+    "configurations": [
+        {
+            "name": "Linux",
+            "includePath": [
+                "${workspaceFolder}/**"
+            ],
+            "defines": [],
+            "compilerPath": "/usr/bin/gcc",
+            "cStandard": "c11",
+            "cppStandard": "gnu++14",
+            "intelliSenseMode": "linux-gcc-x64"
+        }
+    ],
+    "version": 4
+}

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,17 @@
+# Object files
+objects = cuevm.o cuevm_test.o stack.o uint256.o
+
+# Compiler
 NVCC = nvcc
-NVCC_FLAGS = -I./include -lstdc++
 
-all: cuEVM
+# Compiler Flags
+NVCC_FLAGS = -I./include -lstdc++ -dc
 
-cuEVM:
-	$(NVCC) $(NVCC_FLAGS) -o cuEVM src/cu_evm.cu
+all: $(objects)
+	$(NVCC) $(objects) -o cuEVM
+
+%.o: src/%.cu
+	$(NVCC) $(NVCC_FLAGS) $< -o $@
 
 clean:
-	rm -f cuEVM
+	rm -f *.o cuEVM

--- a/include/cuevm_test.h
+++ b/include/cuevm_test.h
@@ -1,0 +1,9 @@
+#ifndef CUEVM_TEST_H
+#define CUEVM_TEST_H
+#include "stack.cuh"
+
+
+void test_arithmetic_operations();
+void test_stack();
+
+#endif // CUEVM_TEST_H

--- a/include/opcode.h
+++ b/include/opcode.h
@@ -1,0 +1,11 @@
+#ifndef OPCODE_H
+#define OPCODE_H
+
+#define ADD 0x01
+#define MUL 0x02
+
+#define POP 0x50
+#define PUSH1 0x60
+// Add other opcode definitions here as your VM expands
+
+#endif // OPCODE_H

--- a/include/stack.cuh
+++ b/include/stack.cuh
@@ -1,0 +1,28 @@
+#ifndef STACK_CUH
+#define STACK_CUH
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdio.h>
+#include <ctype.h>
+#include "uint256.cuh"
+#define STACK_SIZE 100  // For example, temporarily set the stack size of 100
+
+typedef struct {
+    base_uint items[STACK_SIZE];
+    int top;
+} base_uint_stack;
+
+__host__ __device__ void init_stack(base_uint_stack* stack);
+
+__host__ __device__ bool push(base_uint_stack* stack, base_uint item);
+
+__host__ __device__ bool pop(base_uint_stack* stack, base_uint* item);
+
+__host__ __device__ bool swap_with_top(base_uint_stack* stack, int i);
+
+__host__ __device__ void print_stack(base_uint_stack* stack);
+
+
+#endif // STACK_CUH

--- a/include/uint256.cuh
+++ b/include/uint256.cuh
@@ -1,0 +1,60 @@
+// base_uint256.cuh
+
+#ifndef BASE_UINT256_CUH
+#define BASE_UINT256_CUH
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdio.h>
+#include <ctype.h>
+#include <cuda_runtime.h>
+
+#define BITS 256
+#define WIDTH (BITS / 32)
+
+typedef struct
+{
+    uint32_t pn[WIDTH];
+} base_uint;
+
+// utility functions
+__host__ int hexToInt(const char *hex);
+
+__host__ void intToHex(int num, char *hex);
+
+__host__ bool hex_to_decimal(const char *hex_str, char *dec_str);
+
+__host__ __device__  void print_base_uint(const base_uint *val);
+
+// conversion operations
+__host__ bool base_uint_set_hex(base_uint *val, const char *hex);
+
+__host__ void base_uint_to_string(const base_uint *val, char *out_str);
+
+__host__ bool int_to_base_uint(int int_val, base_uint *val);
+
+__host__ __device__ void base_uint_get_hex(const base_uint *val, char *hex);
+
+
+// comparison operations
+__host__ __device__ bool is_zero(const base_uint *num);
+
+// bitwise operations
+__host__ __device__ base_uint bitwise_not(const base_uint *num);
+
+__host__ __device__ void base_uint_set_bit(base_uint *value, uint32_t bitpos);
+
+// arithmetic operations
+
+__host__ __device__ void base_uint_add(const base_uint *a, const base_uint *b, base_uint *result);
+
+__host__ __device__ bool base_uint_sub(const base_uint *a, const base_uint *b, base_uint *result);
+
+__host__ __device__ void base_uint_mul(const base_uint *a, const base_uint *b, base_uint *result);
+
+__host__ __device__ void base_uint_shift_left(base_uint *a, size_t bits);
+
+__host__ __device__ void base_uint_div(const base_uint *a, const base_uint *b, base_uint *quotient, base_uint *remainder);
+
+#endif // BASE_UINT256_CUH

--- a/src/cuevm_test.cu
+++ b/src/cuevm_test.cu
@@ -1,0 +1,131 @@
+#include "cuevm_test.h"
+
+void test_arithmetic_operations()
+{
+    base_uint a, b, c, d;
+
+    // Test addition
+    base_uint_set_hex(&a, "11111111111111111111111111111111");
+    base_uint_set_hex(&b, "22222222222222222222222222222222");
+    base_uint_add(&a, &b, &c);
+    printf("Addition Result: ");
+
+    char buffer[BITS / 4 + 1] = {0};
+    base_uint_get_hex(&c, buffer);
+
+    printf("%s\n", buffer);
+
+    if (strcmp(buffer, "0000000000000000000000000000000033333333333333333333333333333333") != 0)
+    {
+        printf("Addition failed!\n");
+    }
+    // Test addition with carry
+    base_uint_set_hex(&a, "1");
+    base_uint_set_hex(&b, "ffffffffffffffffffffffffffffffff");
+    base_uint_add(&a, &b, &c);
+    printf("Addition Result: ");
+
+    base_uint_get_hex(&c, buffer);
+
+    printf("%s\n", buffer);
+
+    if (strcmp(buffer, "0000000000000000000000000000000100000000000000000000000000000000") != 0)
+    {
+        printf("Addition failed!\n");
+    }
+    // Test addition overflow carry
+    base_uint_set_hex(&a, "1234");
+    base_uint_set_hex(&b, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    base_uint_add(&a, &b, &c);
+    printf("Addition Result: ");
+
+    base_uint_get_hex(&c, buffer);
+
+    printf("%s\n", buffer);
+
+    if (strcmp(buffer, "0000000000000000000000000000000000000000000000000000000000001233") != 0)
+    {
+        printf("Addition failed!\n");
+    }
+
+    // Test subtraction
+    base_uint_set_hex(&a, "ffffffffffffffffffffffffffffffff");
+    base_uint_set_hex(&b, "fe");
+    base_uint_sub(&a, &b, &c);
+    printf("Subtraction Result: ");
+    base_uint_get_hex(&c, buffer);
+    printf("%s\n", buffer);
+    if (strcmp(buffer, "00000000000000000000000000000000ffffffffffffffffffffffffffffff01") != 0)
+    {
+        printf("Subtraction failed!\n");
+    }
+
+    // Test subtraction underflow
+    base_uint_set_hex(&a, "01");
+    base_uint_set_hex(&b, "ff");
+    base_uint_sub(&a, &b, &c);
+    printf("Subtraction Result: ");
+    base_uint_get_hex(&c, buffer);
+    printf("%s\n", buffer);
+    if (strcmp(buffer, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff02") != 0)
+    {
+        printf("Subtraction failed!\n");
+    }
+
+    // Test multiplication
+    base_uint_set_hex(&a, "ffffffffffffffffffffffffffffffff");
+    base_uint_set_hex(&b, "ffffffffffffffffffffffffffffff");
+    base_uint_mul(&a, &b, &c);
+    printf("Multiplication Result: ");
+    base_uint_get_hex(&c, buffer);
+    printf("%s\n", buffer);
+    if (strcmp(buffer, "00fffffffffffffffffffffffffffffeff000000000000000000000000000001") != 0)
+    {
+        printf("Multiplication failed!\n");
+    }
+    // Test multiplication overflow
+    base_uint_set_hex(&a, "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
+    base_uint_set_hex(&b, "2");
+    base_uint_mul(&a, &b, &c);
+    printf("Multiplication Result: ");
+    base_uint_get_hex(&c, buffer);
+    printf("%s\n", buffer);
+    if (strcmp(buffer, "0000000000000000000000000000000000000000000000000000000000000000") != 0)
+    {
+        printf("Multiplication overflow failed!\n");
+    }
+
+}
+
+
+void test_stack() {
+    base_uint_stack stack;
+    init_stack(&stack);
+
+    // Test push and print
+    base_uint a = { {1, 2, 3, 4} };
+    printf("Pushing: ");
+    for (int i = 0; i < WIDTH; i++) printf("%u ", a.pn[i]);
+    printf("\n");
+    push(&stack, a);
+    print_stack(&stack);
+
+    // Test pop
+    base_uint b;
+    if (pop(&stack, &b)) {
+        printf("Popped: ");
+        for (int i = 0; i < WIDTH; i++) printf("%u ", b.pn[i]);
+        printf("\n");
+    }
+    print_stack(&stack);
+
+    // Test swap with top
+    push(&stack, a);
+    base_uint c = { {5, 6, 7, 8} };
+    push(&stack, c);
+    printf("Before swap with top:\n");
+    print_stack(&stack);
+    swap_with_top(&stack, 0);
+    printf("After swap with top:\n");
+    print_stack(&stack);
+}

--- a/src/stack.cu
+++ b/src/stack.cu
@@ -1,0 +1,46 @@
+#include "stack.cuh"
+
+__host__ __device__ void init_stack(base_uint_stack* stack) {
+    stack->top = -1;
+}
+
+__host__ __device__ bool push(base_uint_stack* stack, base_uint item) {
+    if (stack->top >= STACK_SIZE - 1) {
+        return false;  // Stack is full
+    }
+    stack->top++;
+    stack->items[stack->top] = item;
+    return true;
+}
+
+__host__ __device__ bool pop(base_uint_stack* stack, base_uint* item) {
+    if (stack->top < 0) {
+        return false;  // Stack is empty
+    }
+    *item = stack->items[stack->top];
+    stack->top--;
+    return true;
+}
+
+__host__ __device__ bool swap_with_top(base_uint_stack* stack, int i) {
+    if (stack->top < 0 || i > stack->top || i < 0) {
+        return false;  // Stack is empty or index out of bounds
+    }
+    base_uint temp = stack->items[i];
+    stack->items[i] = stack->items[stack->top];
+    stack->items[stack->top] = temp;
+    return true;
+}
+
+__host__ __device__ void print_stack(base_uint_stack* stack) {
+    printf("Stack: ");
+    for (int i = 0; i <= stack->top; i++) {
+        printf("[");
+        for (int j = 0; j < WIDTH; j++) {
+            printf("%u", stack->items[i].pn[j]);
+            if (j < WIDTH - 1) printf(",");
+        }
+        printf("] ");
+    }
+    printf("\n");
+}

--- a/src/uint256.cu
+++ b/src/uint256.cu
@@ -1,0 +1,253 @@
+
+#include "uint256.cuh"
+// implementation
+__host__ int hexToInt(const char *hex)
+{
+    int result = 0;
+    int len = strlen(hex);
+
+    for (int i = 0; i < len; i++)
+    {
+        char c = tolower(hex[i]);
+        if (c >= '0' && c <= '9')
+        {
+            result = result * 16 + (c - '0');
+        }
+        else if (c >= 'a' && c <= 'f')
+        {
+            result = result * 16 + (c - 'a' + 10);
+        }
+        else
+        {
+            // Invalid hexadecimal character
+            return -1;
+        }
+    }
+    return result;
+}
+
+__host__ void intToHex(int num, char *hex)
+{
+    // Assuming hex has enough space
+    char *ptr = hex;
+    do
+    {
+        int remainder = num % 16;
+        if (remainder < 10)
+        {
+            *ptr++ = '0' + remainder;
+        }
+        else
+        {
+            *ptr++ = 'a' + (remainder - 10);
+        }
+        num /= 16;
+    } while (num != 0);
+
+    *ptr-- = '\0'; // NULL-terminate the string and point to the last valid character
+
+    // Reverse the string
+    char *start = hex;
+    while (start < ptr)
+    {
+        char t = *start;
+        *start = *ptr;
+        *ptr = t;
+        start++;
+        ptr--;
+    }
+}
+
+__host__  bool hex_to_decimal(const char *hex_str, char *dec_str)
+{
+    unsigned long long result = 0;
+    unsigned long long place = 1;
+
+    int len = strlen(hex_str);
+    for (int i = len - 1; i >= 0; i--)
+    {
+        char c = tolower(hex_str[i]);
+        int digit;
+        if (c >= '0' && c <= '9')
+        {
+            digit = c - '0';
+        }
+        else if (c >= 'a' && c <= 'f')
+        {
+            digit = 10 + (c - 'a');
+        }
+        else
+        {
+            return false;
+        }
+
+        result += digit * place;
+        place *= 16;
+    }
+
+    sprintf(dec_str, "%llu", result);
+    return true;
+}
+
+__host__  bool base_uint_set_hex(base_uint *val, const char *hex)
+{
+    memset(val->pn, 0, sizeof(val->pn));
+
+    size_t len = strlen(hex);
+    if (len == 0 || len > BITS / 4)
+        return false;
+
+    // Iterate through the string from end to start
+    for (size_t i = 0; i < len; i++)
+    {
+        char c = tolower(hex[len - 1 - i]);
+        uint32_t number = 0;
+
+        if (c >= '0' && c <= '9')
+        {
+            number = c - '0';
+        }
+        else if (c >= 'a' && c <= 'f')
+        {
+            number = c - 'a' + 10;
+        }
+        else
+        {
+            return false; // Invalid character
+        }
+
+        // Determine which uint32_t element and position the hex character should be placed
+        val->pn[i / 8] |= (number << ((i % 8) * 4));
+    }
+    return true;
+}
+
+__host__  void base_uint_to_string(const base_uint *val, char *out_str)
+{
+    char hex_str[BITS / 4 + 1] = {0};
+    base_uint_get_hex(val, hex_str);
+
+    if (!hex_to_decimal(hex_str, out_str))
+    {
+        strcpy(out_str, "Error");
+    }
+}
+
+__host__  bool int_to_base_uint(int int_val, base_uint *val)
+{
+    char *p;
+    sprintf(p, "%08x", int_val);
+    printf("%s\n", p);
+    return base_uint_set_hex(val, p);
+}
+
+__host__ __device__  void base_uint_get_hex(const base_uint *val, char *hex)
+{
+    char *p = hex;
+
+    for (int i = WIDTH - 1; i >= 0; i--)
+    {
+        // printf("%d ", val->pn[i]);
+        sprintf(p, "%08x", val->pn[i]);
+        p += 8;
+    }
+}
+
+__host__ __device__  void print_base_uint(const base_uint *val)
+{
+    for (int i = 0; i < WIDTH; i++)
+    {
+        printf("%d ", val->pn[i]);
+    }
+}
+
+__host__ __device__ bool is_zero(const base_uint *num)
+{
+    for (int i = 0; i < WIDTH; i++)
+    {
+        if (num->pn[i] != 0)
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+__host__ __device__ base_uint bitwise_not(const base_uint *num)
+{
+    base_uint ret;
+    for (int i = 0; i < WIDTH; i++)
+    {
+        ret.pn[i] = ~num->pn[i];
+    }
+    return ret;
+}
+
+__host__ __device__ void base_uint_set_bit(base_uint *value, uint32_t bitpos)
+{
+    value->pn[bitpos / 32] |= (1 << (bitpos % 32));
+}
+
+__host__ __device__ void base_uint_add(const base_uint *a, const base_uint *b, base_uint *result)
+{
+    uint64_t carry = 0;
+
+    for (size_t i = 0; i < WIDTH; i++)
+    {
+        uint64_t sum = (uint64_t)a->pn[i] + b->pn[i] + carry;
+        printf("%d %d = %d %d\n", a->pn[i], b->pn[i], sum, carry);
+        result->pn[i] = (uint32_t)sum; // Store lower 32 bits
+        carry = sum >> 32;             // Take upper 32 bits as the next carry
+    }
+}
+
+__host__ __device__ bool base_uint_sub(const base_uint *a, const base_uint *b, base_uint *result)
+{
+    uint64_t borrow = 0;
+
+    for (size_t i = 0; i < WIDTH; i++)
+    {
+        uint64_t res = 0x100000000ULL + (uint64_t)a->pn[i] - b->pn[i] - borrow;
+        result->pn[i] = (uint32_t)res;
+        if (res >= 0x100000000ULL)
+        {
+            borrow = 0;
+        }
+        else
+        {
+            borrow = 1;
+        }
+    }
+
+    // If borrow is still 1 after looping through all words, then a < b.
+    // Return false to indicate underflow
+    return borrow == 0;
+}
+
+/*
+Warming:
+1. Not tested yet.
+2. Overflow wraparound is not correctly implemented yet.
+*/
+__host__ __device__ void base_uint_mul(const base_uint *a, const base_uint *b, base_uint *result)
+{
+    base_uint temp_result = {0};
+    for (size_t i = 0; i < WIDTH; i++)
+    {
+        uint64_t carry = 0;
+        for (size_t j = 0; j < WIDTH; j++)
+        {
+            if (i + j < WIDTH)
+            {
+                uint64_t product = (uint64_t)a->pn[i] * b->pn[j] + temp_result.pn[i + j] + carry;
+                temp_result.pn[i + j] = (uint32_t)product;
+                carry = product >> 32;
+            }
+        }
+    }
+
+    for (size_t i = 0; i < WIDTH; i++)
+    {
+        result->pn[i] = temp_result.pn[i];
+    }
+}


### PR DESCRIPTION
Sample working EVM with a few opcodes & stack :
* Read bytecode and execute opcodes on stack (temporarily 100 fixed size) 
* Uint256 minimal implementation (buggy & incomplete)

There is no support for `RETURN` opcode yet because it needs `MEMORY` to be implemented

Sample testing bytecode :
```
0x6006 PUSH1 0x06
0x6007 PUSH1 0x07
0x02 MUL 
0x50 POP // Return 42
```
// MUL
0x600660070250 => POP 42 from the stack

// ADD
0x600660070150 => POP 13 from the stack


Sample run: 
```
./cuEVM --bytecode 0x600660070250 --input 0x1234
Bytecode: 60 06 60 07 02 50 
Input: 12 34 
PUSH1 OPCODE: 
push_val: 6 0 0 0 0 0 0 0 
***************
PUSH1 OPCODE: 
push_val: 7 0 0 0 0 0 0 0 
***************
MUL OPCODE: 
op1: 7 0 0 0 0 0 0 0 op2: 6 0 0 0 0 0 0 0 result: 42 0 0 0 0 0 0 0 
***************
Popped Stack value: 42 0 0 0 0 0 0 0 
***************
```