### PR TITLE
zero padding bytes to hex

### DIFF
--- a/src/contract.cuh
+++ b/src/contract.cuh
@@ -43,7 +43,7 @@ class state_t {
 
     state_data_t            *_content;
     arith_t     _arith;
-  
+
     //constructor
     __host__ __device__ __forceinline__ state_t(arith_t arith, state_data_t *content) : _arith(arith), _content(content) {
     }
@@ -253,7 +253,7 @@ class state_t {
             #endif
             error_code = ERR_SUCCESS;
         }
-        
+
         #ifdef  __CUDA_ARCH__
         __syncthreads();
         if(threadIdx.x == 0) {
@@ -681,7 +681,7 @@ class state_t {
         return cpu_local_states;
     }
 
-    
+
 
     __host__ cJSON *to_json() {
         cJSON *state_json = NULL;
@@ -702,15 +702,15 @@ class state_t {
             contract_json = cJSON_CreateObject();
             // set the address
             to_mpz(address, _content->contracts[idx].address._limbs, params::BITS/32);
-            strcpy(hex_string+2, mpz_get_str(NULL, 16, address));
+            strcpy(hex_string+2, pad_with_zero_if_odd(NULL, 16, address));
             cJSON_AddItemToObject(state_json, hex_string, contract_json);
             // set the balance
             to_mpz(balance, _content->contracts[idx].balance._limbs, params::BITS/32);
-            strcpy(hex_string+2, mpz_get_str(NULL, 16, balance));
+            strcpy(hex_string+2, pad_with_zero_if_odd(NULL, 16, balance));
             cJSON_AddStringToObject(contract_json, "balance", hex_string);
             // set the nonce
             to_mpz(nonce, _content->contracts[idx].nonce._limbs, params::BITS/32);
-            strcpy(hex_string+2, mpz_get_str(NULL, 16, nonce));
+            strcpy(hex_string+2, pad_with_zero_if_odd(NULL, 16, nonce));
             cJSON_AddStringToObject(contract_json, "nonce", hex_string);
             // set the code
             if (_content->contracts[idx].code_size > 0) {
@@ -732,9 +732,9 @@ class state_t {
             if (_content->contracts[idx].storage_size > 0) {
                 for (jdx=0; jdx<_content->contracts[idx].storage_size; jdx++) {
                     to_mpz(key, _content->contracts[idx].storage[jdx].key._limbs, params::BITS/32);
-                    strcpy(hex_string+2, mpz_get_str(NULL, 16, key));
+                    strcpy(hex_string+2, pad_with_zero_if_odd(NULL, 16, key));
                     to_mpz(value, _content->contracts[idx].storage[jdx].value._limbs, params::BITS/32);
-                    strcpy(value_hex_string+2, mpz_get_str(NULL, 16, value));
+                    strcpy(value_hex_string+2, pad_with_zero_if_odd(NULL, 16, value));
                     cJSON_AddStringToObject(storage_json, hex_string, value_hex_string);
                 }
             }

--- a/src/message.cuh
+++ b/src/message.cuh
@@ -9,12 +9,12 @@ class message_t {
     typedef arith_env_t<params>                     arith_t;
     typedef typename arith_t::bn_t                  bn_t;
     typedef cgbn_mem_t<params::BITS>                evm_word_t;
-  
+
     typedef struct {
       evm_word_t origin;
       evm_word_t gasprice;
     } tx_t;
-    
+
     typedef struct {
       size_t    size;
       uint8_t   *data;
@@ -207,40 +207,40 @@ class message_t {
       mpz_init(tx_origin);
       mpz_init(tx_gasprice);
       mpz_init(gas);
-      
+
       // set the caller
       to_mpz(caller, _content->caller._limbs, params::BITS/32);
-      strcpy(hex_string+2, mpz_get_str(NULL, 16, caller));
+      strcpy(hex_string+2, pad_with_zero_if_odd(NULL, 16, caller));
       cJSON_AddStringToObject(transaction_json, "sender", hex_string);
-      
+
       // set the value
       to_mpz(value, _content->value._limbs, params::BITS/32);
-      strcpy(hex_string+2, mpz_get_str(NULL, 16, value));
+      strcpy(hex_string+2, pad_with_zero_if_odd(NULL, 16, value));
       cJSON_AddStringToObject(transaction_json, "value", hex_string);
 
       // set the to
       to_mpz(to, _content->to._limbs, params::BITS/32);
-      strcpy(hex_string+2, mpz_get_str(NULL, 16, to));
+      strcpy(hex_string+2, pad_with_zero_if_odd(NULL, 16, to));
       cJSON_AddStringToObject(transaction_json, "to", hex_string);
 
       // set the nonce
       to_mpz(nonce, _content->nonce._limbs, params::BITS/32);
-      strcpy(hex_string+2, mpz_get_str(NULL, 16, nonce));
+      strcpy(hex_string+2, pad_with_zero_if_odd(NULL, 16, nonce));
       cJSON_AddStringToObject(transaction_json, "nonce", hex_string);
 
       // set the tx.origin
       to_mpz(tx_origin, _content->tx.origin._limbs, params::BITS/32);
-      strcpy(hex_string+2, mpz_get_str(NULL, 16, tx_origin));
+      strcpy(hex_string+2, pad_with_zero_if_odd(NULL, 16, tx_origin));
       cJSON_AddStringToObject(transaction_json, "origin", hex_string);
 
       // set the tx.gasprice
       to_mpz(tx_gasprice, _content->tx.gasprice._limbs, params::BITS/32);
-      strcpy(hex_string+2, mpz_get_str(NULL, 16, tx_gasprice));
+      strcpy(hex_string+2, pad_with_zero_if_odd(NULL, 16, tx_gasprice));
       cJSON_AddStringToObject(transaction_json, "gasPrice", hex_string);
 
       // set the gas
       to_mpz(gas, _content->gas._limbs, params::BITS/32);
-      strcpy(hex_string+2, mpz_get_str(NULL, 16, gas));
+      strcpy(hex_string+2, pad_with_zero_if_odd(NULL, 16, gas));
       cJSON_AddStringToObject(transaction_json, "gasLimit", hex_string);
 
       // set the data
@@ -369,7 +369,7 @@ class message_t {
       return cpu_messages;
     }
 
-    
+
     __host__ static void free_messages(message_content_t *cpu_messages, size_t count) {
       for(size_t idx=0; idx<count; idx++) {
         // data
@@ -397,7 +397,7 @@ class message_t {
       free(tmp_cpu_messages);
       return gpu_messages;
     }
-  
+
     __host__ static void free_gpu_messages(message_content_t *gpu_messages, size_t count) {
       message_content_t *tmp_cpu_messages;
       tmp_cpu_messages = (message_content_t *)malloc(count*sizeof(message_content_t));

--- a/src/stack.cuh
+++ b/src/stack.cuh
@@ -25,7 +25,7 @@ class stack_t {
   static const uint32_t                           STACK_SIZE = params::STACK_SIZE;
   static const uint32_t                           WORD_BITS = params::BITS;
   static const uint32_t                           WORD_BYTES = params::BITS/8;
-  
+
   typedef struct {
     evm_word_t values[params::STACK_SIZE];
   } stack_content_data_t;
@@ -37,7 +37,7 @@ class stack_t {
 
   stack_data_t  *_content;
   arith_t     _arith;
-  
+
   //constructor
   __host__ __device__ __forceinline__ stack_t(arith_t arith, stack_data_t *content) : _arith(arith), _content(content) {
   }
@@ -90,8 +90,8 @@ class stack_t {
     cgbn_sub(_arith._env, r, a, b);
     push(r, error_code);
   }
-  
-  
+
+
   __host__ __device__ __forceinline__ void negate(uint32_t &error_code) {
     bn_t  a, r;
     pop(a, error_code);
@@ -159,7 +159,7 @@ class stack_t {
       cgbn_rem(_arith._env, r, a, b);
     push(r, error_code);
   }
-  
+
   __host__ __device__ __forceinline__ void smod(uint32_t &error_code) {
     bn_t  a, b, r;
     pop(a, error_code);
@@ -291,7 +291,7 @@ class stack_t {
     cgbn_set_ui32(_arith._env, r, result);
     push(r, error_code);
   }
-  
+
   __host__ __device__ __forceinline__ int32_t scompare(uint32_t &error_code) {
     bn_t  a, b;
     pop(a, error_code);
@@ -423,7 +423,7 @@ class stack_t {
 
     if (cgbn_compare_ui32(_arith._env, shift, WORD_BITS-1) == 1)
       shift_right = WORD_BITS;
-   
+
     cgbn_shift_right(_arith._env, r, value, shift_right);
     if (sign_b == 1) {
       cgbn_bitwise_mask_ior(_arith._env, r, r, -shift_right);
@@ -452,7 +452,7 @@ class stack_t {
     }
     return _content->stack_base + _content->stack_offset - index;
   }
-  
+
 
   __host__ __device__ __forceinline__ void dupx(uint32_t index, uint32_t &error_code) {
     if (index < 1 || index > 16) {
@@ -467,7 +467,7 @@ class stack_t {
     cgbn_load(_arith._env, r, value);
     push(r, error_code);
   }
-  
+
 
   __host__ __device__ __forceinline__ void swapx(uint32_t index, uint32_t &error_code) {
     if (index < 1 || index > 16) {
@@ -536,7 +536,7 @@ class stack_t {
     mpz_init(mpz_stack_value);
     cJSON *stack_json = cJSON_CreateObject();
 
-    
+
     mpz_set_ui(mpz_stack_size, size());
     // as hex string
     //strcpy(hex_string+2, mpz_get_str(NULL, 16, mpz_stack_size));
@@ -548,7 +548,7 @@ class stack_t {
     uint32_t print_size = full ? STACK_SIZE : size();
     for(uint32_t idx=0;idx<print_size;idx++) {
       to_mpz(mpz_stack_value, _content->stack_base[idx]._limbs, params::BITS/32);
-      strcpy(hex_string+2, mpz_get_str(NULL, 16, mpz_stack_value));
+      strcpy(hex_string+2, pad_with_zero_if_odd(NULL, 16, mpz_stack_value));
       cJSON_AddItemToArray(stack_data_json, cJSON_CreateString(hex_string));
     }
     cJSON_AddItemToObject(stack_json, "data", stack_data_json);
@@ -557,7 +557,7 @@ class stack_t {
     return stack_json;
   }
 
-  
+
   // support routine to generate instances
   __host__ static stack_data_t *get_stacks(uint32_t count) {
     stack_data_t *stacks=(stack_data_t *)malloc(sizeof(stack_data_t)*count);


### PR DESCRIPTION
Turns out the encoding function `bytes_to_hex` in utils.h is not used at all. The one actually is in use is from GMP `mpz_get_str`. 

Created a wapper function for `mpz_get_str` `pad_with_zero_if_odd` which padding leading zeros. I've tested with cpu_interpreter, but please feel free to update if you see any problems. @sdcioc 

