### PR TITLE
EIP-3155: support comparing EVMs through goevmlab

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ cpu_interpreter:
 	$(NVCC) -D ONLY_CPU $(TRACER_FLAG) $(NVCC_FLAGS) -o $(OUT_DIRECTORY)/$@ src/interpreter.cu
 
 cpu_debug_interpreter:
-	$(NVCC) -D TRACER -D COMPLEX_TRACER -D ONLY_CPU -D GAS $(NVCC_FLAGS) -g -G -o $(OUT_DIRECTORY)/$@ src/interpreter.cu
+	$(NVCC) -D TRACER -D COMPLEX_TRACER -D ONLY_CPU -D GAS $(NVCC_FLAGS) -O0 -g -G -o $(OUT_DIRECTORY)/$@ src/interpreter.cu
 
 % :: src/test/%.cu
 	$(NVCC) $(NVCC_FLAGS) -g -G -o $(OUT_DIRECTORY)/$@ $<

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Compiler
 NVCC = nvcc
-NVCC_FLAGS = -I./CGBN/include -lstdc++ -lm -lgmp -lcjson -rdc=true --std c++20 -lcudadevrt -lineinfo 
+NVCC_FLAGS = -I./CGBN/include -lstdc++ -lm -lgmp -lcjson -rdc=true --std c++20 -lcudadevrt -lineinfo
 GCC = gcc
 GCC_FLAGS = -lm -lgmp -lcjson
 GPP = g++
@@ -32,7 +32,7 @@ interpreter:
 	$(NVCC) $(TRACER_FLAG) $(NVCC_FLAGS) -o $(OUT_DIRECTORY)/$@ src/interpreter.cu
 
 debug_interpreter:
-	$(NVCC) -D TRACER $(NVCC_FLAGS) -g -G -o $(OUT_DIRECTORY)/$@ src/interpreter.cu
+	$(NVCC) -D TRACER -D COMPLEX_TRACER -D GAS $(NVCC_FLAGS) -g -G -o $(OUT_DIRECTORY)/$@ src/interpreter.cu
 
 cpu_interpreter:
 	$(NVCC) -D ONLY_CPU $(TRACER_FLAG) -D GAS $(NVCC_FLAGS) -g -G -o $(OUT_DIRECTORY)/$@ src/interpreter.cu

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ debug_interpreter:
 	$(NVCC) -D TRACER -D COMPLEX_TRACER -D GAS $(NVCC_FLAGS) -arch=$(SM_ARCH) -g -lineinfo -o $(OUT_DIRECTORY)/$@ src/interpreter.cu
 
 cpu_interpreter:
-	$(NVCC) -D ONLY_CPU $(TRACER_FLAG) -D GAS $(NVCC_FLAGS) -g -G -o $(OUT_DIRECTORY)/$@ src/interpreter.cu
+	$(NVCC) -D ONLY_CPU $(TRACER_FLAG) $(NVCC_FLAGS) -o $(OUT_DIRECTORY)/$@ src/interpreter.cu
 
 cpu_debug_interpreter:
 	$(NVCC) -D TRACER -D COMPLEX_TRACER -D ONLY_CPU -D GAS $(NVCC_FLAGS) -g -G -o $(OUT_DIRECTORY)/$@ src/interpreter.cu

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GPP_FLAGS = -I./CGBN/include -lm -lgmp -lcjson
 OUT_DIRECTORY = ./out
 
 ENABLE_TRACING ?= 0
-
+SM_ARCH ?= sm_89
 ifeq ($(ENABLE_TRACING),1)
     TRACER_FLAG = -D TRACER
 else
@@ -29,10 +29,10 @@ test_cgbn: src/test/test_cgbn.cu
 	$(NVCC) $(NVCC_FLAGS) -o $(OUT_DIRECTORY)/test_cgbn src/test/test_cgbn.cu
 
 interpreter:
-	$(NVCC) $(TRACER_FLAG) $(NVCC_FLAGS) -o $(OUT_DIRECTORY)/$@ src/interpreter.cu
+	$(NVCC) $(TRACER_FLAG) $(NVCC_FLAGS) -arch=$(SM_ARCH) -o $(OUT_DIRECTORY)/$@ src/interpreter.cu
 
 debug_interpreter:
-	$(NVCC) -D TRACER -D COMPLEX_TRACER -D GAS $(NVCC_FLAGS) -g -G -o $(OUT_DIRECTORY)/$@ src/interpreter.cu
+	$(NVCC) -D TRACER -D COMPLEX_TRACER -D GAS $(NVCC_FLAGS) -arch=$(SM_ARCH) -g -lineinfo -o $(OUT_DIRECTORY)/$@ src/interpreter.cu
 
 cpu_interpreter:
 	$(NVCC) -D ONLY_CPU $(TRACER_FLAG) -D GAS $(NVCC_FLAGS) -g -G -o $(OUT_DIRECTORY)/$@ src/interpreter.cu

--- a/samples/eth-tests/arith_loop.json
+++ b/samples/eth-tests/arith_loop.json
@@ -1,0 +1,72 @@
+{
+    "arith" : {
+        "_info" : {
+            "comment" : "Ori Pomerantz qbzzt1@gmail.com",
+            "filling-rpc-server" : "evm version 1.13.5-unstable-cd295356-20231019",
+            "filling-tool-version" : "retesteth-0.3.1-cancun+commit.1e18e0b3.Linux.g++",
+            "generatedTestHash" : "2bc2140a7c47eba44121c604cfb606102667e0c430c6d36bd025ed4f35e40192",
+            "lllcversion" : "Version: 0.5.14-develop.2023.7.11+commit.c58ab2c6.mod.Linux.g++",
+            "solidity" : "Version: 0.8.21+commit.d9974bed.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/VMTests/vmArithmeticTest/arithFiller.yml",
+            "sourceHash" : "b8806024134ce9bf944ec1331e05479ef3d5d0b342825d2c42d076dc4f59f5e2"
+        },
+        "env" : {
+            "currentBaseFee" : "0x0a",
+            "currentBeaconRoot" : "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05f5e100",
+            "currentNumber" : "0x01",
+            "currentRandom" : "0x0000000000000000000000000000000000000000000000000000000000020000",
+            "currentTimestamp" : "0x03e8",
+            "currentWithdrawalsRoot" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Shanghai" : [
+                {
+                    "hash" : "0xd925c572f80a2025bf52dd642447f07c637efae5cb509ca82856ce3b1435e4b5",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                    "txbytes" : "0xf861800a8404c4b40094cccccccccccccccccccccccccccccccccccccccc01001ca06939410fcd80efd44b8d819c37a4e460b38e39f37d99e1f09ccd9c25753ef79aa017a79fccc1ede0aae2dbb9f810acc5d6ece485338b3d695742b607a3b886a2b1"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x0ba1a9ce0ba1a9ce",
+                "code" : "0x",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xcccccccccccccccccccccccccccccccccccccccc" : {
+                "balance" : "0x0ba1a9ce0ba1a9ce",
+                "code" : "0x608060405234801561000f575f80fd5b506004361061004a575f3560e01c80631b8268d51461004e578063410b3cba1461007e5780635966322b146100ae578063a01d2f87146100de575b5f80fd5b6100686004803603810190610063919061021b565b61010e565b6040516100759190610255565b60405180910390f35b6100986004803603810190610093919061021b565b610122565b6040516100a59190610255565b60405180910390f35b6100c860048036038101906100c3919061021b565b610153565b6040516100d59190610255565b60405180910390f35b6100f860048036038101906100f3919061021b565b6101b6565b6040516101059190610255565b60405180910390f35b5f602052805f5260405f205f915090505481565b5f805b8281101561014d57600182019150600282029150600282049150818255600181019050610125565b50919050565b5f805f90505f838260405160200161016c92919061026e565b6040516020818303038152906040528051906020012090505f5b848110156101ae57600184019350600284029350600284049350838255600181019050610186565b505050919050565b5f805b828110156101de576001820191506002820291506002820491506001810190506101b9565b50919050565b5f80fd5b5f819050919050565b6101fa816101e8565b8114610204575f80fd5b50565b5f81359050610215816101f1565b92915050565b5f602082840312156102305761022f6101e4565b5b5f61023d84828501610207565b91505092915050565b61024f816101e8565b82525050565b5f6020820190506102685f830184610246565b92915050565b5f6040820190506102815f830185610246565b61028e6020830184610246565b939250505056fea2646970667358221220af44865a7e8145cca154e9078ba5b06fce9629b27f609e706cb2dc5be1e8518e64736f6c63430008180033",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0xa01d2f8700000000000000000000000000000000000000000000000000000000000000ff"
+            ],
+            "gasLimit" : [
+                "0x04c4b400"
+            ],
+            "gasPrice" : "0x0a",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "sender" : "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "to" : "0xcccccccccccccccccccccccccccccccccccccccc",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/samples/eth-tests/arith_loop_write_mapping.json
+++ b/samples/eth-tests/arith_loop_write_mapping.json
@@ -1,0 +1,72 @@
+{
+    "arith" : {
+        "_info" : {
+            "comment" : "Ori Pomerantz qbzzt1@gmail.com",
+            "filling-rpc-server" : "evm version 1.13.5-unstable-cd295356-20231019",
+            "filling-tool-version" : "retesteth-0.3.1-cancun+commit.1e18e0b3.Linux.g++",
+            "generatedTestHash" : "2bc2140a7c47eba44121c604cfb606102667e0c430c6d36bd025ed4f35e40192",
+            "lllcversion" : "Version: 0.5.14-develop.2023.7.11+commit.c58ab2c6.mod.Linux.g++",
+            "solidity" : "Version: 0.8.21+commit.d9974bed.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/VMTests/vmArithmeticTest/arithFiller.yml",
+            "sourceHash" : "b8806024134ce9bf944ec1331e05479ef3d5d0b342825d2c42d076dc4f59f5e2"
+        },
+        "env" : {
+            "currentBaseFee" : "0x0a",
+            "currentBeaconRoot" : "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05f5e100",
+            "currentNumber" : "0x01",
+            "currentRandom" : "0x0000000000000000000000000000000000000000000000000000000000020000",
+            "currentTimestamp" : "0x03e8",
+            "currentWithdrawalsRoot" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Shanghai" : [
+                {
+                    "hash" : "0x4c6e15a60aaab17fd64cdb35d269c1a4035566d57a8f9f29a88271b703d94132",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                    "txbytes" : "0xf861800a8404c4b40094cccccccccccccccccccccccccccccccccccccccc01001ca06939410fcd80efd44b8d819c37a4e460b38e39f37d99e1f09ccd9c25753ef79aa017a79fccc1ede0aae2dbb9f810acc5d6ece485338b3d695742b607a3b886a2b1"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x0ba1a9ce0ba1a9ce",
+                "code" : "0x",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xcccccccccccccccccccccccccccccccccccccccc" : {
+                "balance" : "0x0ba1a9ce0ba1a9ce",
+                "code" : "0x608060405234801561000f575f80fd5b506004361061004a575f3560e01c80631b8268d51461004e578063410b3cba1461007e5780635966322b146100ae578063a01d2f87146100de575b5f80fd5b6100686004803603810190610063919061021b565b61010e565b6040516100759190610255565b60405180910390f35b6100986004803603810190610093919061021b565b610122565b6040516100a59190610255565b60405180910390f35b6100c860048036038101906100c3919061021b565b610153565b6040516100d59190610255565b60405180910390f35b6100f860048036038101906100f3919061021b565b6101b6565b6040516101059190610255565b60405180910390f35b5f602052805f5260405f205f915090505481565b5f805b8281101561014d57600182019150600282029150600282049150818255600181019050610125565b50919050565b5f805f90505f838260405160200161016c92919061026e565b6040516020818303038152906040528051906020012090505f5b848110156101ae57600184019350600284029350600284049350838255600181019050610186565b505050919050565b5f805b828110156101de576001820191506002820291506002820491506001810190506101b9565b50919050565b5f80fd5b5f819050919050565b6101fa816101e8565b8114610204575f80fd5b50565b5f81359050610215816101f1565b92915050565b5f602082840312156102305761022f6101e4565b5b5f61023d84828501610207565b91505092915050565b61024f816101e8565b82525050565b5f6020820190506102685f830184610246565b92915050565b5f6040820190506102815f830185610246565b61028e6020830184610246565b939250505056fea2646970667358221220af44865a7e8145cca154e9078ba5b06fce9629b27f609e706cb2dc5be1e8518e64736f6c63430008180033",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x5966322b00000000000000000000000000000000000000000000000000000000000000ff"
+            ],
+            "gasLimit" : [
+                "0x04c4b400"
+            ],
+            "gasPrice" : "0x0a",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "sender" : "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "to" : "0xcccccccccccccccccccccccccccccccccccccccc",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/samples/eth-tests/arith_loop_write_storage.json
+++ b/samples/eth-tests/arith_loop_write_storage.json
@@ -1,0 +1,72 @@
+{
+    "arith" : {
+        "_info" : {
+            "comment" : "Ori Pomerantz qbzzt1@gmail.com",
+            "filling-rpc-server" : "evm version 1.13.5-unstable-cd295356-20231019",
+            "filling-tool-version" : "retesteth-0.3.1-cancun+commit.1e18e0b3.Linux.g++",
+            "generatedTestHash" : "2bc2140a7c47eba44121c604cfb606102667e0c430c6d36bd025ed4f35e40192",
+            "lllcversion" : "Version: 0.5.14-develop.2023.7.11+commit.c58ab2c6.mod.Linux.g++",
+            "solidity" : "Version: 0.8.21+commit.d9974bed.Linux.g++",
+            "source" : "src/GeneralStateTestsFiller/VMTests/vmArithmeticTest/arithFiller.yml",
+            "sourceHash" : "b8806024134ce9bf944ec1331e05479ef3d5d0b342825d2c42d076dc4f59f5e2"
+        },
+        "env" : {
+            "currentBaseFee" : "0x0a",
+            "currentBeaconRoot" : "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x020000",
+            "currentGasLimit" : "0x05f5e100",
+            "currentNumber" : "0x01",
+            "currentRandom" : "0x0000000000000000000000000000000000000000000000000000000000020000",
+            "currentTimestamp" : "0x03e8",
+            "currentWithdrawalsRoot" : "0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421",
+            "previousHash" : "0x5e20a0453cecd065ea59c37ac63e079ee08998b6045136a8ce6635c7912ec0b6"
+        },
+        "post" : {
+            "Shanghai" : [
+                {
+                    "hash" : "0x4c6e15a60aaab17fd64cdb35d269c1a4035566d57a8f9f29a88271b703d94132",
+                    "indexes" : {
+                        "data" : 0,
+                        "gas" : 0,
+                        "value" : 0
+                    },
+                    "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+                    "txbytes" : "0xf861800a8404c4b40094cccccccccccccccccccccccccccccccccccccccc01001ca06939410fcd80efd44b8d819c37a4e460b38e39f37d99e1f09ccd9c25753ef79aa017a79fccc1ede0aae2dbb9f810acc5d6ece485338b3d695742b607a3b886a2b1"
+                }
+            ]
+        },
+        "pre" : {
+            "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" : {
+                "balance" : "0x0ba1a9ce0ba1a9ce",
+                "code" : "0x",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            },
+            "0xcccccccccccccccccccccccccccccccccccccccc" : {
+                "balance" : "0x0ba1a9ce0ba1a9ce",
+                "code" : "0x608060405234801561000f575f80fd5b506004361061004a575f3560e01c80631b8268d51461004e578063410b3cba1461007e5780635966322b146100ae578063a01d2f87146100de575b5f80fd5b6100686004803603810190610063919061021b565b61010e565b6040516100759190610255565b60405180910390f35b6100986004803603810190610093919061021b565b610122565b6040516100a59190610255565b60405180910390f35b6100c860048036038101906100c3919061021b565b610153565b6040516100d59190610255565b60405180910390f35b6100f860048036038101906100f3919061021b565b6101b6565b6040516101059190610255565b60405180910390f35b5f602052805f5260405f205f915090505481565b5f805b8281101561014d57600182019150600282029150600282049150818255600181019050610125565b50919050565b5f805f90505f838260405160200161016c92919061026e565b6040516020818303038152906040528051906020012090505f5b848110156101ae57600184019350600284029350600284049350838255600181019050610186565b505050919050565b5f805b828110156101de576001820191506002820291506002820491506001810190506101b9565b50919050565b5f80fd5b5f819050919050565b6101fa816101e8565b8114610204575f80fd5b50565b5f81359050610215816101f1565b92915050565b5f602082840312156102305761022f6101e4565b5b5f61023d84828501610207565b91505092915050565b61024f816101e8565b82525050565b5f6020820190506102685f830184610246565b92915050565b5f6040820190506102815f830185610246565b61028e6020830184610246565b939250505056fea2646970667358221220af44865a7e8145cca154e9078ba5b06fce9629b27f609e706cb2dc5be1e8518e64736f6c63430008180033",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        },
+        "transaction" : {
+            "data" : [
+                "0x410b3cba00000000000000000000000000000000000000000000000000000000000000ff"
+            ],
+            "gasLimit" : [
+                "0x04c4b400"
+            ],
+            "gasPrice" : "0x0a",
+            "nonce" : "0x00",
+            "secretKey" : "0x45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8",
+            "sender" : "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b",
+            "to" : "0xcccccccccccccccccccccccccccccccccccccccc",
+            "value" : [
+                "0x00"
+            ]
+        }
+    }
+}

--- a/scripts/run-ethtest-by-fork.py
+++ b/scripts/run-ethtest-by-fork.py
@@ -1,0 +1,99 @@
+# python run-ethtest-by-fork.py -i . -t /tmp/out/ --runtest-bin runtest --geth geth --cuevm cuevm --ignore-errors
+
+import json
+import subprocess
+import shutil
+
+def assert_command_in_path(cmd):
+    if not shutil.which(cmd):
+        raise ValueError(f"{cmd} not found in PATH")
+
+def clean_test_out():
+    subprocess.run('rm *.jsonl', shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+def read_as_json_lines(filepath):
+    with open(filepath, 'r', encoding='utf-8') as f:
+        for line in f:
+            yield json.loads(line)
+
+def compare_output():
+    geth_traces = list(read_as_json_lines('geth-0-output.jsonl'))
+    cuevm_traces = list(read_as_json_lines('cuevm-0-output.jsonl'))
+
+    if len(geth_traces) != len(cuevm_traces) or len(geth_traces) < 2:
+        raise ValueError("\033[91m💥\033[0m Mismatched trace length")
+
+    if geth_traces[0] != cuevm_traces[0]:
+        raise ValueError("\033[91m💥\033[0m Mismatched traces")
+
+def run_single_test(output_filepath, runtest_bin, geth_bin, cuevm_bin):
+    command = [runtest_bin, f'--geth={geth_bin}', f'--cuevm={cuevm_bin}', output_filepath]
+
+    print(' '.join(command))
+
+    clean_test_out()
+    subprocess.run(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    compare_output()
+
+    print(f"\033[92m🎉\033[0m Test passed for {output_filepath}")
+
+def runtest_fork(input_directory, output_directory, fork='Shanghai', runtest_bin='runtest', geth_bin='geth', cuevm_bin='cuevm', ignore_errors=False):
+    for dirpath, dirnames, filenames in os.walk(input_directory):
+        rel_path = os.path.relpath(dirpath, input_directory)
+        for filename in filenames:
+            rootname = filename.split('.')[0]
+            try:
+                if filename.endswith(".json"):
+                    input_filepath = os.path.join(dirpath, filename)
+
+                    with open(input_filepath, 'r', encoding='utf-8') as file:
+                        data = json.load(file)
+
+                    post_data = data[rootname]['post']
+
+                    if fork not in post_data:
+                        print(f"No entries related to Shanghai found in {input_filepath}. Skipping...")
+                        continue
+
+                    post_data = {key: value for key, value in post_data.items() if key == fork}
+
+                    # unwrap the transactions, otherwise only the first transaction gets tested
+                    test_index = 0
+                    for test in post_data[fork]:
+                        data[rootname]['post'] = {fork: [test]}
+                        output_filepath = os.path.join(output_directory, rel_path, f'{test_index}', filename)
+                        os.makedirs(os.path.dirname(output_filepath), exist_ok=True)
+                        with open(output_filepath, 'w', encoding='utf-8') as file:
+                            json.dump(data, file, ensure_ascii=False, indent=2)
+
+                        print(f"Processed and saved {output_filepath} successfully.")
+                        run_single_test(output_filepath, runtest_bin, geth_bin, cuevm_bin)
+                        test_index += 1
+            except Exception as e:
+                if ignore_errors:
+                    print(f"{str(e)}")
+                else:
+                    raise
+
+
+
+def main():
+    import os
+    import argparse
+    parser = argparse.ArgumentParser(description='Filter JSON files for entries related to "Shanghai"')
+    parser.add_argument('--input', '-i',  type=str, required=True, help='Input directory containing JSON files')
+    parser.add_argument('--temporary-path', '-t', type=str, required=True, help='Temporary directory to save the test files')
+    parser.add_argument('--runtest-bin', type=str, required=True, help='goevmlab runtest binary path')
+    parser.add_argument('--geth', type=str, required=True, help='geth binary path')
+    parser.add_argument('--cuevm', type=str, required=True, help='cuevm binary path')
+    parser.add_argument('--ignore-errors', action='store_true', help='Continue testing even when test errors occur')
+
+    args = parser.parse_args()
+
+    for cmd in [args.runtest_bin, args.geth, args.cuevm]:
+        assert_command_in_path(cmd)
+
+    runtest_fork(args.input, args.temporary_path, fork='Shanghai', runtest_bin=args.runtest_bin, geth_bin=args.geth, cuevm_bin=args.cuevm, ignore_errors=args.ignore_errors)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run-ethtest-by-fork.py
+++ b/scripts/run-ethtest-by-fork.py
@@ -1,8 +1,9 @@
 # python run-ethtest-by-fork.py -i . -t /tmp/out/ --runtest-bin runtest --geth geth --cuevm cuevm --ignore-errors
-
+import copy
 import json
 import subprocess
 import shutil
+import os
 
 def assert_command_in_path(cmd):
     if not shutil.which(cmd):
@@ -37,7 +38,8 @@ def run_single_test(output_filepath, runtest_bin, geth_bin, cuevm_bin):
 
     print(f"\033[92m🎉\033[0m Test passed for {output_filepath}")
 
-def runtest_fork(input_directory, output_directory, fork='Shanghai', runtest_bin='runtest', geth_bin='geth', cuevm_bin='cuevm', ignore_errors=False):
+def runtest_fork(input_directory, output_directory, fork='Shanghai', runtest_bin='runtest', geth_bin='geth', cuevm_bin='cuevm', ignore_errors=False, result={}):
+    result = result or {'n_total': 0, 'n_success': 0}
     for dirpath, dirnames, filenames in os.walk(input_directory):
         rel_path = os.path.relpath(dirpath, input_directory)
         for filename in filenames:
@@ -57,19 +59,52 @@ def runtest_fork(input_directory, output_directory, fork='Shanghai', runtest_bin
 
                     post_data = {key: value for key, value in post_data.items() if key == fork}
 
-                    # unwrap the transactions, otherwise only the first transaction gets tested
+                    # unwrap the transactions because cuevm does not lookup by index currently
+                    transaction_data = data[rootname]['transaction']['data']
+                    transaction_gaslimit = data[rootname]['transaction']['gasLimit']
+                    transaction_value = data[rootname]['transaction']['value']
+                    transaction = data[rootname]['transaction']
+
                     test_index = 0
                     for test in post_data[fork]:
+                        data = copy.deepcopy(data)
                         data[rootname]['post'] = {fork: [test]}
+                        indexes = test.get('indexes', {})
+                        test_data_index = indexes.get('data')
+                        test_value_index = indexes.get('value')
+                        test_gas_index =  indexes.get('gas')
+
+                        new_transaction = copy.deepcopy(transaction)
+
+                        if test_data_index is not None:
+                            new_transaction['data'] = [ transaction_data[test_data_index], ]
+                            indexes['data'] = 0
+
+                        if test_value_index is not None:
+                            new_transaction['value'] = [ transaction_value[test_value_index], ]
+                            indexes['value'] = 0
+
+                        if test_gas_index is not None:
+                            new_transaction['gasLimit'] = [ transaction_gaslimit[test_gas_index], ]
+                            indexes['gas'] = 0
+
                         output_filepath = os.path.join(output_directory, rel_path, f'{test_index}', filename)
                         os.makedirs(os.path.dirname(output_filepath), exist_ok=True)
+
+                        data[rootname]['transaction'] = new_transaction
+
                         with open(output_filepath, 'w', encoding='utf-8') as file:
                             json.dump(data, file, ensure_ascii=False, indent=2)
 
                         print(f"Processed and saved {output_filepath} successfully.")
                         run_single_test(output_filepath, runtest_bin, geth_bin, cuevm_bin)
                         test_index += 1
+                        if result:
+                            result['n_success'] += 1
+                            result['n_total'] += 1
             except Exception as e:
+                if result:
+                    result['n_total'] += 1
                 if ignore_errors:
                     print(f"{str(e)}")
                 else:
@@ -78,7 +113,6 @@ def runtest_fork(input_directory, output_directory, fork='Shanghai', runtest_bin
 
 
 def main():
-    import os
     import argparse
     parser = argparse.ArgumentParser(description='Filter JSON files for entries related to "Shanghai"')
     parser.add_argument('--input', '-i',  type=str, required=True, help='Input directory containing JSON files')
@@ -93,7 +127,12 @@ def main():
     for cmd in [args.runtest_bin, args.geth, args.cuevm]:
         assert_command_in_path(cmd)
 
-    runtest_fork(args.input, args.temporary_path, fork='Shanghai', runtest_bin=args.runtest_bin, geth_bin=args.geth, cuevm_bin=args.cuevm, ignore_errors=args.ignore_errors)
+    result = {'n_total': 0, 'n_success': 0}
+    try:
+        runtest_fork(args.input, args.temporary_path, fork='Shanghai', runtest_bin=args.runtest_bin, geth_bin=args.geth, cuevm_bin=args.cuevm, ignore_errors=args.ignore_errors, result=result)
+    finally:
+        print(f"Total tests: {result['n_total']}, Passed: {result['n_success']}")
+
 
 if __name__ == "__main__":
     main()

--- a/src/alu_operations.cuh
+++ b/src/alu_operations.cuh
@@ -1400,7 +1400,7 @@ namespace bitwise_operations{
         uint32_t &pc,
         stack_t &stack)
     {
-        cgbn_add_ui32(arith._env, gas_used, gas_used, GAS_LOW);
+        cgbn_add_ui32(arith._env, gas_used, gas_used, GAS_VERY_LOW);
         if (arith.has_gas(gas_limit, gas_used, error_code))
         {
             bn_t shift, value;

--- a/src/alu_operations.cuh
+++ b/src/alu_operations.cuh
@@ -687,7 +687,7 @@ namespace stack_operations{
      * @param[inout] stack The stack.
      * @param[in] bytecode The bytecode.
      * @param[in] code_size The size of the bytecode.
-     * @param[in] opcode The opcode. 
+     * @param[in] opcode The opcode.
     */
     __host__ __device__ __forceinline__ static void operation_PUSHX(
         arith_t &arith,
@@ -1434,7 +1434,7 @@ namespace bitwise_operations{
      * The first value is considered unsigned and the second value is considered
      * signed.
      * @param[in] arith The arithmetical environment.
-     * @param[in] gas_limit The gas limit. 
+     * @param[in] gas_limit The gas limit.
      * @param[inout] gas_used The gas used.
      * @param[out] error_code The error code.
      * @param[out] pc The program counter.
@@ -1448,7 +1448,7 @@ namespace bitwise_operations{
         uint32_t &pc,
         stack_t &stack)
     {
-        cgbn_add_ui32(arith._env, gas_used, gas_used, GAS_LOW);
+        cgbn_add_ui32(arith._env, gas_used, gas_used, GAS_VERY_LOW);
         if (arith.has_gas(gas_limit, gas_used, error_code))
         {
             bn_t shift, value;

--- a/src/alu_operations.cuh
+++ b/src/alu_operations.cuh
@@ -1355,7 +1355,7 @@ namespace bitwise_operations{
         uint32_t &pc,
         stack_t &stack)
     {
-        cgbn_add_ui32(arith._env, gas_used, gas_used, GAS_LOW);
+        cgbn_add_ui32(arith._env, gas_used, gas_used, GAS_VERY_LOW);
         if (arith.has_gas(gas_limit, gas_used, error_code))
         {
             bn_t shift, value;

--- a/src/block.cuh
+++ b/src/block.cuh
@@ -45,6 +45,7 @@ public:
   {
     evm_word_t coin_base; /**< The address of the block miner (YP: \f$H_{c}\f$) */
     evm_word_t difficulty; /**< The difficulty of the block (YP: \f$H_{d}\f$) */
+    evm_word_t prevrandao; /**< The prevrandao EIP-4399 */
     evm_word_t number; /**< The number of the block (YP: \f$H_{i}\f$) */
     evm_word_t gas_limit; /**< The gas limit of the block (YP: \f$H_{l}\f$) */
     evm_word_t time_stamp; /**< The timestamp of the block (YP: \f$H_{s}\f$) */
@@ -117,6 +118,15 @@ public:
       _content->difficulty,
       element_json->valuestring
     );
+
+    element_json = cJSON_GetObjectItemCaseSensitive(block_json, "currentRandom");
+    if (element_json != NULL)
+    {
+      _arith.cgbn_memory_from_hex_string(
+        _content->prevrandao,
+        element_json->valuestring
+      );
+    }
 
     element_json = cJSON_GetObjectItemCaseSensitive(block_json, "currentGasLimit");
     _arith.cgbn_memory_from_hex_string(
@@ -236,6 +246,12 @@ public:
     bn_t &difficulty)
   {
     cgbn_load(_arith._env, difficulty, &(_content->difficulty));
+  }
+
+  __host__ __device__ __forceinline__ void get_prevrandao(
+    bn_t &val)
+  {
+    cgbn_load(_arith._env, val, &(_content->prevrandao));
   }
 
   /**

--- a/src/block.cuh
+++ b/src/block.cuh
@@ -161,10 +161,11 @@ public:
       _arith.cgbn_memory_from_size_t(_content->previous_blocks[0].number, 0);
 
       element_json = cJSON_GetObjectItemCaseSensitive(block_json, "previousHash");
-      _arith.cgbn_memory_from_hex_string(
-        _content->previous_blocks[0].hash,
-        element_json->valuestring
-      );
+
+      if (element_json != NULL){
+        _arith.cgbn_memory_from_hex_string(_content->previous_blocks[0].hash, element_json->valuestring);
+      }
+
       idx++;
     }
 

--- a/src/env_operations.cuh
+++ b/src/env_operations.cuh
@@ -192,8 +192,8 @@ namespace block_operations{
         {
             bn_t prev_randao;
             // TODO: to change depending on the evm version
-            // block.get_prev_randao(prev_randao);
-            block.get_difficulty(prev_randao);
+            block.get_prevrandao(prev_randao); // Assuming after merge fork
+            // block.get_difficulty(prev_randao);
 
             stack.push(prev_randao, error_code);
 
@@ -340,7 +340,7 @@ namespace environmental_operations{
      * - word_size = (length + 31) / 32
      * - dynamic_gas_cost = word_size * GAS_KECCAK256_WORD
      * Adittional gas cost is added for the memory expansion.
-     * 
+     *
      * @param[in] arith The arithmetical environment.
      * @param[in] gas_limit The gas limit.
      * @param[inout] gas_used The gas used.
@@ -686,7 +686,7 @@ namespace environmental_operations{
      * - word_size = (length + 31) / 32
      * - dynamic_gas_cost = word_size * GAS_MEMORY
      * Adittional gas cost is added for the memory expansion.
-     * 
+     *
      * @param[in] arith The arithmetical environment.
      * @param[in] gas_limit The gas limit.
      * @param[inout] gas_used The gas used.
@@ -756,7 +756,7 @@ namespace environmental_operations{
     /**
      * The CODESIZE operation implementation.
      * Pushes on the stack the size of code running in current environment.
-     * 
+     *
      * @param[in] arith The arithmetical environment.
      * @param[in] gas_limit The gas limit.
      * @param[inout] gas_used The gas used.
@@ -800,7 +800,7 @@ namespace environmental_operations{
      * - word_size = (length + 31) / 32
      * - dynamic_gas_cost = word_size * GAS_MEMORY
      * Adittional gas cost is added for the memory expansion.
-     * 
+     *
      * @param[in] arith The arithmetical environment.
      * @param[in] gas_limit The gas limit.
      * @param[inout] gas_used The gas used.
@@ -876,7 +876,7 @@ namespace environmental_operations{
      * The GASPRICE operation implementation.
      * Pushes on the stack the gas price of the current transaction.
      * The gas price is the price per unit of gas in the transaction.
-     * 
+     *
      * @param[in] arith The arithmetical environment.
      * @param[in] gas_limit The gas limit.
      * @param[inout] gas_used The gas used.
@@ -920,7 +920,7 @@ namespace environmental_operations{
      * of the account with that address.
      * Gas is charged for accessing the account if it is warm
      * or cold access.
-     * 
+     *
      * @param[in] arith The arithmetical environment.
      * @param[in] gas_limit The gas limit.
      * @param[inout] gas_used The gas used.
@@ -974,7 +974,7 @@ namespace environmental_operations{
      * Adittional gas cost is added for the memory expansion.
      * Gas is charged for accessing the account if it is warm
      * or cold access.
-     * 
+     *
      * @param[in] arith The arithmetical environment.
      * @param[in] gas_limit The gas limit.
      * @param[inout] gas_used The gas used.
@@ -1054,7 +1054,7 @@ namespace environmental_operations{
     /**
      * The RETURNDATASIZE operation implementation.
      * Pushes on the stack the size of the return data of the last call.
-     * 
+     *
      * @param[in] arith The arithmetical environment.
      * @param[in] gas_limit The gas limit.
      * @param[inout] gas_used The gas used.
@@ -1097,7 +1097,7 @@ namespace environmental_operations{
      * - word_size = (length + 31) / 32
      * - dynamic_gas_cost = word_size * GAS_MEMORY
      * Adittional gas cost is added for the memory expansion.
-     * 
+     *
      * @param[in] arith The arithmetical environment.
      * @param[in] gas_limit The gas limit.
      * @param[inout] gas_used The gas used.
@@ -1185,7 +1185,7 @@ namespace environmental_operations{
      * or cold access.
      * If the account does not exist or is empty or the account is
      * selfdestructed, the hash is zero.
-     * 
+     *
      * @param[in] arith The arithmetical environment.
      * @param[in] gas_limit The gas limit.
      * @param[inout] gas_used The gas used.
@@ -1260,7 +1260,7 @@ namespace environmental_operations{
      * Pushes on the stack the balance of the current contract.
      * The current contract is consider the contract that owns the
      * execution code.
-     * 
+     *
      * @param[in] arith The arithmetical environment.
      * @param[in] gas_limit The gas limit.
      * @param[inout] gas_used The gas used.

--- a/src/evm.cuh
+++ b/src/evm.cuh
@@ -3326,11 +3326,12 @@ public:
  * @param[out] report error report
  * @param[in] instances evm instances
 */
+template <class params>
 __global__ void kernel_evm(
     cgbn_error_report_t *report,
     typename evm_t::evm_instances_t *instances)
 {
-    uint32_t instance = (blockIdx.x * blockDim.x + threadIdx.x) / evm_params::TPI;
+    uint32_t instance = (blockIdx.x * blockDim.x + threadIdx.x) / params::TPI;
 
     if (instance >= instances->count)
         return;
@@ -3341,7 +3342,7 @@ __global__ void kernel_evm(
         report,
         instance);
 
-    // setup evm 
+    // setup evm
     evm_t evm (
         arith,
         instances->world_state_data,

--- a/src/evm.cuh
+++ b/src/evm.cuh
@@ -2728,7 +2728,7 @@ public:
                 }
             }
 #ifdef TRACER
-        cgbn_set(_arith._env, _tracer->_content->last_gas_used, _gas_useds[_depth]);
+        cgbn_store(_arith._env, &_tracer->_content->last_gas_used, _gas_useds[_depth]);
 #endif
             // If the operation ended with halting
             // can be normal or exceptional
@@ -3108,6 +3108,8 @@ public:
         gpu_instances.touch_states_data = touch_state_t::get_gpu_instances_from_cpu_instances(cpu_instances.touch_states_data, cpu_instances.count);
 
         gpu_instances.logs_data = log_state_t::get_gpu_instances_from_cpu_instances(cpu_instances.logs_data, cpu_instances.count);
+
+        gpu_instances.return_data = return_data_t::get_gpu_instances_from_cpu_instances(cpu_instances.return_data, cpu_instances.count);
 
 #ifdef TRACER
         gpu_instances.tracers_data = tracer_t::get_gpu_instances_from_cpu_instances(cpu_instances.tracers_data, cpu_instances.count);

--- a/src/evm.cuh
+++ b/src/evm.cuh
@@ -860,7 +860,7 @@ public:
                         error_code,
                         new_message);
 
-                    memory.grow_cost(args_offset, args_size, gas_used, error_code); // CREATE_GAS_UPDATE: memory_expansion_cost
+                    // memory.grow_cost(args_offset, args_size, gas_used, error_code); // CREATE_GAS_UPDATE: memory_expansion_cost
 
                 }
                 else

--- a/src/evm.cuh
+++ b/src/evm.cuh
@@ -1696,6 +1696,7 @@ public:
             _tracer->push(
                 _trace_address,
                 _trace_pc,
+                _depth,
                 _trace_opcode,
                 *_stack_ptrs[_depth],
                 *_memory_ptrs[_depth],

--- a/src/evm.cuh
+++ b/src/evm.cuh
@@ -1688,8 +1688,7 @@ public:
             {
                 _opcode = _bytecode[_pcs[_depth]];
             }
-            ONE_THREAD_PER_INSTANCE(
-                printf("pc: %d opcode: %d\n", _pcs[_depth], _opcode);)
+            // ONE_THREAD_PER_INSTANCE(printf("pc: %d opcode: %d\n", _pcs[_depth], _opcode);)
 #ifdef TRACER
             _trace_pc = _pcs[_depth];
             _trace_opcode = _opcode;
@@ -3029,7 +3028,8 @@ public:
     */
     __host__ static void get_cpu_instances(
         evm_instances_t &instances,
-        const cJSON *test)
+        const cJSON *test,
+        size_t clones=1)
     {
         //setup the arithmetic environment
         arith_t arith(cgbn_report_monitor, 0);
@@ -3056,7 +3056,7 @@ public:
         keccak = NULL;
 
         // get the transactions
-        transaction_t::get_transactions(instances.transactions_data, test, instances.count);
+        transaction_t::get_transactions(instances.transactions_data, test, instances.count, 0, clones);
 
         // allocated the memory for accessed states
         instances.accessed_states_data = accessed_state_t::get_cpu_instances(instances.count);
@@ -3207,39 +3207,46 @@ public:
     */
     __host__ static void print_evm_instances_t(
         arith_t &arith,
-        evm_instances_t instances)
+        evm_instances_t instances,
+        bool verbose = false)
     {
-        world_state_t *cpu_world_state;
-        cpu_world_state = new world_state_t(arith, instances.world_state_data);
-        printf("World state:\n");
-        cpu_world_state->print();
-        delete cpu_world_state;
-        cpu_world_state = NULL;
+        printf("verbose mode %d\n", verbose);
+        if (verbose){
+            world_state_t *cpu_world_state;
+            cpu_world_state = new world_state_t(arith, instances.world_state_data);
+            printf("World state:\n");
+            cpu_world_state->print();
+            delete cpu_world_state;
+            cpu_world_state = NULL;
 
-        block_t *cpu_block = NULL;
-        cpu_block = new block_t(arith, instances.block_data);
-        printf("Block:\n");
-        cpu_block->print();
-        delete cpu_block;
-        cpu_block = NULL;
-        printf("return data count %lu\n", instances.return_data[0].size);
-        printf("Instances:\n");
+            block_t *cpu_block = NULL;
+            cpu_block = new block_t(arith, instances.block_data);
+            printf("Block:\n");
+            cpu_block->print();
+            delete cpu_block;
+            cpu_block = NULL;
+            printf("return data count %lu\n", instances.return_data[0].size);
+            printf("Instances:\n");
+        }
         for (size_t idx = 0; idx < instances.count; idx++)
         {
-            printf("Instance %lu\n", idx);
-            transaction_t::print_transaction_data_t(arith, instances.transactions_data[idx]);
+            if (verbose){
+                printf("Instance %lu\n", idx);
+                transaction_t::print_transaction_data_t(arith, instances.transactions_data[idx]);
 
-            accessed_state_t::print_accessed_state_data_t(arith, instances.accessed_states_data[idx]);
+                accessed_state_t::print_accessed_state_data_t(arith, instances.accessed_states_data[idx]);
 
-            touch_state_t::print_touch_state_data_t(arith, instances.touch_states_data[idx]);
+                touch_state_t::print_touch_state_data_t(arith, instances.touch_states_data[idx]);
 
-            log_state_t::print_log_state_data_t(arith, instances.logs_data[idx]);
+                log_state_t::print_log_state_data_t(arith, instances.logs_data[idx]);
+
+                printf("Error: %u\n", instances.errors[idx]);
+            }
 
 #ifdef TRACER
             tracer_t::print_tracer_data_t(arith, instances.tracers_data[idx], &instances.return_data[idx]);
 #endif
 
-            printf("Error: %u\n", instances.errors[idx]);
         }
     }
 

--- a/src/evm.cuh
+++ b/src/evm.cuh
@@ -732,14 +732,6 @@ public:
                     evm.child_CALL(
                         error_code,
                         new_message);
-                    // todo return gas unused in child call
-                    memory.grow_cost(args_offset,
-                                     args_size,
-                                     gas_used,
-                                     error_code);
-
-                    // compute the initcode gas cost
-                    arith.initcode_cost(gas_used, args_size);
                 }
                 else
                 {

--- a/src/evm.cuh
+++ b/src/evm.cuh
@@ -1691,6 +1691,18 @@ public:
 #ifdef TRACER
             _trace_pc = _pcs[_depth];
             _trace_opcode = _opcode;
+            _tracer->push(
+                _trace_address,
+                _trace_pc,
+                _trace_opcode,
+                *_stack_ptrs[_depth],
+                *_memory_ptrs[_depth],
+                *_touch_state_ptrs[_depth],
+                _gas_useds[_depth],
+                _gas_limit,
+                _gas_refunds[_depth],
+                error_code);
+
 #endif
             // PUSHX
             if (((_opcode & 0xF0) == 0x60) || ((_opcode & 0xF0) == 0x70))
@@ -2730,19 +2742,6 @@ public:
                 // if it is the root call
                 if (_depth == 0)
                 {
-#ifdef TRACER
-                    _tracer->push(
-                        _trace_address,
-                        _trace_pc,
-                        _trace_opcode,
-                        *_stack_ptrs[_depth],
-                        *_memory_ptrs[_depth],
-                        *_touch_state_ptrs[_depth],
-                        _gas_useds[_depth],
-                        _gas_limit,
-                        _gas_refunds[_depth],
-                        error_code);
-#endif
                     finish_TRANSACTION(error_code);
                     free_CALL();
                     return;
@@ -2753,36 +2752,10 @@ public:
                     free_CALL();
                     _depth = _depth - 1;
                     update_CALL();
-#ifdef TRACER
-                    _tracer->push(
-                        _trace_address,
-                        _trace_pc,
-                        _trace_opcode,
-                        *_stack_ptrs[_depth],
-                        *_memory_ptrs[_depth],
-                        *_touch_state_ptrs[_depth],
-                        _gas_useds[_depth],
-                        _gas_limit,
-                        _gas_refunds[_depth],
-                        error_code);
-#endif
                 }
             }
             else
             {
-#ifdef TRACER
-                _tracer->push(
-                    _trace_address,
-                    _trace_pc,
-                    _trace_opcode,
-                    *_stack_ptrs[_depth],
-                    *_memory_ptrs[_depth],
-                    *_touch_state_ptrs[_depth],
-                    _gas_useds[_depth],
-                    _gas_limit,
-                    _gas_refunds[_depth],
-                    error_code);
-#endif
             }
         }
     }

--- a/src/include/arith.cuh
+++ b/src/include/arith.cuh
@@ -214,7 +214,7 @@ public:
    * @param[in] count The number of limbs
   */
   __host__ void hex_string_from_cgbn_memory(
-    char *dst_hex_string, 
+    char *dst_hex_string,
     evm_word_t &src_cgbn_mem,
     uint32_t count = LIMBS
   )
@@ -230,6 +230,49 @@ public:
       );
     }
     dst_hex_string[count * 8 + 2] = '\0';
+  }
+  /*
+    * Get a pretty hex string from the CGBn memory.
+    * The hex string is in Big Endian format.
+    * The hex string must be allocated by the caller.
+    * @param[out] dst_hex_string The destination hex string
+    * @param[in] src_cgbn_mem The source CGBN memory
+    * @param[in] count The number of limbs
+  */
+  __host__ void pretty_hex_string_from_cgbn_memory(
+    char *dst_hex_string,
+    evm_word_t &src_cgbn_mem,
+    uint32_t count = LIMBS
+  )
+  {
+    dst_hex_string[0] = '0';
+    dst_hex_string[1] = 'x';
+    int offset = 2; // Start after "0x"
+
+    for (uint32_t idx = 0, first = 1; idx < count; ++idx)
+    {
+      uint32_t value = src_cgbn_mem._limbs[count - 1 - idx];
+      if (value != 0 || !first)
+      {
+        if (first)
+        {
+          first = 0; // No longer at the first non-zero value
+          offset += sprintf(dst_hex_string + offset, "%x", value);
+        }
+        else
+        {
+          offset += sprintf(dst_hex_string + offset, "%08x", value);
+        }
+      }
+    }
+
+    if (offset == 2) // Handle the case where all values are zero
+    {
+      strcpy(dst_hex_string + offset, "0");
+      offset += 1;
+    }
+
+    dst_hex_string[offset] = '\0'; // Null-terminate the string
   }
 
   /**
@@ -347,7 +390,7 @@ public:
       cgbn_div_ui32(_env, gas_capped, gas_left, 64);
       cgbn_sub(_env, gas_capped, gas_left, gas_capped);
   }
-  
+
   /**
    * Get the data at the given index for the given length.
    * If the index is greater than the data size, it returns NULL.

--- a/src/include/arith.cuh
+++ b/src/include/arith.cuh
@@ -205,6 +205,20 @@ public:
       return 0;
     }
   }
+
+
+    /**
+   * Get a uint64_t from a CGBN type.
+   * @param[dst] dst The destination to store the trimmed number
+   * @param[src] src The number to trim down to uint64
+  */
+  __host__ __device__ __forceinline__ void trim_to_uint64(bn_t &dst, bn_t &src)
+  {
+    const uint32_t numbits = 256 - 64;
+    cgbn_shift_left(_env, dst, src, numbits);
+    cgbn_shift_right(_env, dst, src, numbits);
+  }
+
   /**
    * Get a hex string from the CGBn memory.
    * The hex string is in Big Endian format.

--- a/src/interpreter.cu
+++ b/src/interpreter.cu
@@ -146,20 +146,20 @@ int main(int argc, char *argv[]) {//getting the input
           write_json_filename = optarg;
           break;
       default:
-          fprintf(stderr, "Usage: %s --input <json_filename> --output <json_filename>\n", argv[0]);
+          fprintf(stdout, "Usage: %s --input <json_filename> --output <json_filename>\n", argv[0]);
           exit(EXIT_FAILURE);
       }
   }
   if (!read_json_filename || !write_json_filename)
   {
-      fprintf(stderr, "Both --input and --output flags are required\n");
+      fprintf(stdout, "Both --input and --output flags are required\n");
       exit(EXIT_FAILURE);
   }
 
   // check if the file exists
   std::ifstream file(read_json_filename);
   if (!file) {
-    fprintf(stderr, "File '%s' does not exist\n", read_json_filename);
+    fprintf(stdout, "File '%s' does not exist\n", read_json_filename);
     exit(EXIT_FAILURE);
   }
   run_interpreter(read_json_filename, write_json_filename);

--- a/src/interpreter.cu
+++ b/src/interpreter.cu
@@ -37,10 +37,7 @@ void run_interpreter(char *read_json_filename, char *write_json_filename) {
     evm_t::get_gpu_instances(tmp_gpu_instances, cpu_instances);
     CUDA_CHECK(cudaMalloc(&gpu_instances, sizeof(evm_instances_t)));
     CUDA_CHECK(cudaMemcpy(gpu_instances, &tmp_gpu_instances, sizeof(evm_instances_t), cudaMemcpyHostToDevice));
-    #endif
 
-    // create a cgbn_error_report for CGBN to report back errors
-    #ifndef ONLY_CPU
     size_t heap_size, stack_size;
     CUDA_CHECK(cgbn_error_report_alloc(&report));
     cudaDeviceGetLimit(&heap_size, cudaLimitMallocHeapSize);
@@ -54,7 +51,7 @@ void run_interpreter(char *read_json_filename, char *write_json_filename) {
     printf("Running GPU kernel ...\n");
     CUDA_CHECK(cudaDeviceSynchronize());
     kernel_evm<evm_params><<<cpu_instances.count, evm_params::TPI>>>(report, gpu_instances);
-    //CUDA_CHECK(cudaPeekAtLastError());
+    // CUDA_CHECK(cudaPeekAtLastError());
     // error report uses managed memory, so we sync the device (or stream) and check for cgbn errors
     CUDA_CHECK(cudaDeviceSynchronize());
     printf("GPU kernel finished\n");

--- a/src/interpreter.cu
+++ b/src/interpreter.cu
@@ -1,6 +1,6 @@
 #include <getopt.h>
 #include <fstream>
-
+#include <chrono>
 #include "utils.cu"
 #include "evm.cuh"
 
@@ -15,6 +15,10 @@ void run_interpreter(char *read_json_filename, char *write_json_filename, size_t
   evm_instances_t tmp_gpu_instances, *gpu_instances;
   cgbn_error_report_t     *report;
   CUDA_CHECK(cudaDeviceReset());
+  cudaEvent_t start, stop;
+  float milliseconds = 0;
+  CUDA_CHECK(cudaEventCreate(&start));
+  CUDA_CHECK(cudaEventCreate(&stop));
   #endif
 
   arith_t arith(cgbn_report_monitor, 0);
@@ -33,9 +37,14 @@ void run_interpreter(char *read_json_filename, char *write_json_filename, size_t
     printf("%d instances generated\n", cpu_instances.count);
 
     #ifndef ONLY_CPU
+    CUDA_CHECK(cudaEventRecord(start));
     evm_t::get_gpu_instances(tmp_gpu_instances, cpu_instances);
     CUDA_CHECK(cudaMalloc(&gpu_instances, sizeof(evm_instances_t)));
     CUDA_CHECK(cudaMemcpy(gpu_instances, &tmp_gpu_instances, sizeof(evm_instances_t), cudaMemcpyHostToDevice));
+    CUDA_CHECK(cudaEventRecord(stop));
+    CUDA_CHECK(cudaEventSynchronize(stop));
+    CUDA_CHECK(cudaEventElapsedTime(&milliseconds, start, stop));
+    printf("Memcpy HostToDevice took %f ms\n", milliseconds);
 
     size_t heap_size, stack_size;
     CUDA_CHECK(cgbn_error_report_alloc(&report));
@@ -47,26 +56,37 @@ void run_interpreter(char *read_json_filename, char *write_json_filename, size_t
     cudaDeviceGetLimit(&heap_size, cudaLimitMallocHeapSize);
     printf("Heap size: %zu\n", heap_size);
     printf("Running GPU kernel ...\n");
-    CUDA_CHECK(cudaDeviceSynchronize());
+    CUDA_CHECK(cudaEventRecord(start));
+    // CUDA_CHECK(cudaDeviceSynchronize());
     kernel_evm<evm_params><<<cpu_instances.count, evm_params::TPI>>>(report, gpu_instances);
     // CUDA_CHECK(cudaPeekAtLastError());
     // error report uses managed memory, so we sync the device (or stream) and check for cgbn errors
     CUDA_CHECK(cudaDeviceSynchronize());
     printf("GPU kernel finished\n");
     CGBN_CHECK(report);
+    CUDA_CHECK(cudaEventRecord(stop));
+    CUDA_CHECK(cudaEventSynchronize(stop));
+    CUDA_CHECK(cudaEventElapsedTime(&milliseconds, start, stop));
+    printf("Main GPU kernel execution took %f ms\n", milliseconds);
 
     // copy the results back to the CPU
     printf("Copying results back to CPU\n");
+    CUDA_CHECK(cudaEventRecord(start));
     CUDA_CHECK(cudaMemcpy(&tmp_gpu_instances, gpu_instances, sizeof(evm_instances_t), cudaMemcpyDeviceToHost));
     evm_t::get_cpu_instances_from_gpu_instances(cpu_instances, tmp_gpu_instances);
+    CUDA_CHECK(cudaEventRecord(stop));
+    CUDA_CHECK(cudaEventSynchronize(stop));
+    CUDA_CHECK(cudaEventElapsedTime(&milliseconds, start, stop));
+    printf("Memcpy DeviceToHost took %f ms\n", milliseconds);
     printf("Results copied\n");
     #else
     printf("Running CPU EVM\n");
     // run the evm
     evm_t *evm = NULL;
     uint32_t tmp_error;
+    auto cpu_start = std::chrono::high_resolution_clock::now();
     for(uint32_t instance = 0; instance < cpu_instances.count; instance++) {
-      printf("Running instance %d\n", instance);
+      // printf("Running instance %d\n", instance);
       evm = new evm_t(
           arith,
           cpu_instances.world_state_data,
@@ -85,8 +105,12 @@ void run_interpreter(char *read_json_filename, char *write_json_filename, size_t
       evm->run(tmp_error);
       delete evm;
       evm = NULL;
+
     }
     printf("CPU EVM finished\n");
+    auto cpu_end = std::chrono::high_resolution_clock::now();
+    std::chrono::duration<double, std::milli> cpu_duration = cpu_end - cpu_start;
+    printf("CPU EVM execution took %f ms\n", cpu_duration.count());
     #endif
 
 

--- a/src/interpreter.cu
+++ b/src/interpreter.cu
@@ -34,7 +34,7 @@ void run_interpreter(char *read_json_filename, char *write_json_filename, size_t
   cJSON_ArrayForEach(test, read_root) {
     // get instaces to run
     evm_t::get_cpu_instances(cpu_instances, test, clones);
-    printf("%d instances generated\n", cpu_instances.count);
+    printf("%lu instances generated\n", cpu_instances.count);
 
     #ifndef ONLY_CPU
     CUDA_CHECK(cudaEventRecord(start));

--- a/src/interpreter.cu
+++ b/src/interpreter.cu
@@ -81,6 +81,7 @@ void run_interpreter(char *read_json_filename, char *write_json_filename) {
           &(cpu_instances.accessed_states_data[instance]),
           &(cpu_instances.touch_states_data[instance]),
           &(cpu_instances.logs_data[instance]),
+          &(cpu_instances.return_data[instance]),
           #ifdef TRACER
           &(cpu_instances.tracers_data[instance]),
           #endif

--- a/src/no_cgbn/cuevm.cu
+++ b/src/no_cgbn/cuevm.cu
@@ -247,13 +247,13 @@ int main(int argc, char *argv[]) {
                 test_stack();
                 exit(0);
             default:
-                fprintf(stderr, "Usage: %s --bytecode <hexstring> --input <hexstring>\n", argv[0]);
+                fprintf(stdout, "Usage: %s --bytecode <hexstring> --input <hexstring>\n", argv[0]);
                 exit(EXIT_FAILURE);
         }
     }
 
     if (!byte_code_hex || !input_hex) {
-        fprintf(stderr, "Both --bytecode and --input flags are required\n");
+        fprintf(stdout, "Both --bytecode and --input flags are required\n");
         exit(EXIT_FAILURE);
     }
 

--- a/src/tracer.cuh
+++ b/src/tracer.cuh
@@ -372,8 +372,8 @@ public:
             // memory_t::print_memory_data_t(arith, tracer_data.memories[idx]);
             // printf("Touch state:\n");
             // touch_state_t::print_touch_state_data_t(arith, tracer_data.touch_states[idx]);
-            printf("Gas used: ");
-            arith.print_cgbn_memory(tracer_data.gas_useds[idx]);
+            // printf("Gas used: ");
+            // arith.print_cgbn_memory(tracer_data.gas_useds[idx]);
             // printf("Gas limit: ");
             // arith.print_cgbn_memory(tracer_data.gas_limits[idx]);
             // printf("Gas refund: ");

--- a/src/tracer.cuh
+++ b/src/tracer.cuh
@@ -344,6 +344,7 @@ public:
           cgbn_load(arith._env, gas_limit, &tracer_data.gas_limits[idx]);
           cgbn_load(arith._env, gas_used, &tracer_data.gas_useds[idx]);
           cgbn_sub(arith._env, gas_left, gas_limit, gas_used);
+          arith.trim_to_uint64(gas_left, gas_left); // goevmlab assumes gas is uint64
           cgbn_store(arith._env, evm_word, gas_left);
           arith.pretty_hex_string_from_cgbn_memory(gas_left_str, *evm_word);
 

--- a/src/tracer.cuh
+++ b/src/tracer.cuh
@@ -313,14 +313,16 @@ public:
           std::string stack_str = "\"";
           if (stack_data.stack_offset > 0){
             for (auto index =0; index<stack_data.stack_offset; index++){
-              arith.hex_string_from_cgbn_memory(temp, stack_data.stack_base[index]);
+              arith.pretty_hex_string_from_cgbn_memory(temp, stack_data.stack_base[index]);
               stack_str += temp;
               if (index == stack_data.stack_offset - 1) {
                 stack_str += "\"";
               } else {
-                stack_str += "\", ";
+                stack_str += "\",\"";
               }
             }
+          }else{
+            stack_str += "\"";
           }
 
           // calculate gas_cost in this operation
@@ -332,14 +334,14 @@ public:
           cgbn_sub(arith._env, gas_left, gas_limit, gas_used);
           cgbn_add(arith._env, gas_left, gas_left, gas_cost); // gas_left in EIP-3155 is the value before the operation
           cgbn_store(arith._env, evm_word, gas_left);
-          arith.hex_string_from_cgbn_memory(gas_left_str, *evm_word);
+          arith.pretty_hex_string_from_cgbn_memory(gas_left_str, *evm_word);
 
 
 
           // cgbn_store(arith._env, evm_word, gas_cost);
           // arith.hex_string_from_cgbn_memory(gas_cost_str, *evm_word);
 
-          fprintf(stderr, "{\"pc\": %d, \"op\": %d, \"gas\": \"%s\", \"stack\": [%s], \"depth\": %d, \"memSize\": %lu}\n",
+          fprintf(stderr, "{\"pc\":%d,\"op\":%d,\"gas\":\"%s\",\"stack\":[%s],\"depth\":%d,\"memSize\":%lu}\n",
                   tracer_data.pcs[idx],
                   tracer_data.opcodes[idx],
                   gas_left_str, // gas left before this operation
@@ -367,6 +369,9 @@ public:
             printf("Error code: %d\n", tracer_data.error_codes[idx]);
             #endif
         }
+        arith.pretty_hex_string_from_cgbn_memory(gas_left_str, tracer_data.gas_useds[tracer_data.size-1]);
+        printf ("all gas used %s\n", gas_left_str);
+
         delete[] gas_left_str;
         delete[] gas_cost_str;
         delete[] temp;

--- a/src/tracer.cuh
+++ b/src/tracer.cuh
@@ -338,6 +338,7 @@ public:
             cgbn_load(arith._env, gas_used, &tracer_data.gas_useds[idx+1]);
 
           cgbn_sub(arith._env, gas_cost, gas_used, prev_gas_used);
+          arith.trim_to_uint64(gas_cost, gas_cost);
           cgbn_store(arith._env, evm_word, gas_cost);
           arith.pretty_hex_string_from_cgbn_memory(gas_cost_str, *evm_word);
 

--- a/src/tracer.cuh
+++ b/src/tracer.cuh
@@ -83,7 +83,7 @@ public:
         evm_word_t *gas_refunds; /**< The gas refunds*/
         uint32_t *error_codes; /**< The error codes*/
         #endif
-        bn_t last_gas_used; /**< The cost including the last instruction*/
+        evm_word_t last_gas_used; /**< The cost including the last instruction*/
     } tracer_data_t;
 
     tracer_data_t *_content; /**< The content of the tracer*/
@@ -334,7 +334,7 @@ public:
 
           // calculate gas_cost in this operation
           if (idx == tracer_data.size - 1)
-            cgbn_set(arith._env, gas_used, tracer_data.last_gas_used);
+            cgbn_load(arith._env, gas_used, &tracer_data.last_gas_used);
           else
             cgbn_load(arith._env, gas_used, &tracer_data.gas_useds[idx+1]);
 
@@ -363,8 +363,8 @@ public:
             // memory_t::print_memory_data_t(arith, tracer_data.memories[idx]);
             // printf("Touch state:\n");
             // touch_state_t::print_touch_state_data_t(arith, tracer_data.touch_states[idx]);
-            // printf("Gas used: ");
-            // arith.print_cgbn_memory(tracer_data.gas_useds[idx]);
+            printf("Gas used: ");
+            arith.print_cgbn_memory(tracer_data.gas_useds[idx]);
             // printf("Gas limit: ");
             // arith.print_cgbn_memory(tracer_data.gas_limits[idx]);
             // printf("Gas refund: ");
@@ -374,7 +374,8 @@ public:
         }
         #ifdef COMPLEX_TRACER
         cgbn_load(arith._env, prev_gas_used, &tracer_data.gas_useds[0]);
-        cgbn_sub(arith._env, gas_used, tracer_data.last_gas_used, prev_gas_used);
+        cgbn_load(arith._env, gas_limit, &tracer_data.last_gas_used);
+        cgbn_sub(arith._env, gas_used, gas_used, prev_gas_used);
         cgbn_store(arith._env, evm_word, gas_used);
         arith.pretty_hex_string_from_cgbn_memory(gas_left_str, *evm_word);
 

--- a/src/tracer.cuh
+++ b/src/tracer.cuh
@@ -82,8 +82,8 @@ public:
         evm_word_t *gas_limits; /**< The gas limits*/
         evm_word_t *gas_refunds; /**< The gas refunds*/
         uint32_t *error_codes; /**< The error codes*/
-        bn_t last_gas_used; /**< The cost including the last instruction*/
         #endif
+        bn_t last_gas_used; /**< The cost including the last instruction*/
     } tracer_data_t;
 
     tracer_data_t *_content; /**< The content of the tracer*/
@@ -305,8 +305,6 @@ public:
         {
           // todo https://eips.ethereum.org/EIPS/eip-3155
           // maintain a tracer data is costly in terms of memory, maybe we print in the each evm step and do not save data
-            cgbn_load(arith._env, prev_gas_used, &tracer_data.gas_useds[idx]);
-
 
           stack_data = tracer_data.stacks[idx];
 
@@ -323,6 +321,9 @@ public:
               }
             }
           }
+
+          #ifdef COMPLEX_TRACER
+          cgbn_load(arith._env, prev_gas_used, &tracer_data.gas_useds[idx]);
 
           // calculate gas_left
           cgbn_load(arith._env, gas_limit, &tracer_data.gas_limits[idx]);
@@ -357,7 +358,7 @@ public:
             // printf("Opcode: %d\n", tracer_data.opcodes[idx]);
             // printf("Stack:\n");
             // stack_t::print_stack_data_t(arith, tracer_data.stacks[idx]);
-            #ifdef COMPLEX_TRACER
+
             // printf("Memory:\n");
             // memory_t::print_memory_data_t(arith, tracer_data.memories[idx]);
             // printf("Touch state:\n");
@@ -369,8 +370,9 @@ public:
             // printf("Gas refund: ");
             // arith.print_cgbn_memory(tracer_data.gas_refunds[idx]);
             // printf("Error code: %d\n", tracer_data.error_codes[idx]);
-            #endif
+          #endif
         }
+        #ifdef COMPLEX_TRACER
         cgbn_load(arith._env, prev_gas_used, &tracer_data.gas_useds[0]);
         cgbn_sub(arith._env, gas_used, tracer_data.last_gas_used, prev_gas_used);
         cgbn_store(arith._env, evm_word, gas_used);
@@ -380,6 +382,7 @@ public:
             char* return_data_str =  hex_from_bytes(return_data->data, return_data->size);
             fprintf(stderr, "{\"output\":\"%s\",\"gasUsed\":\"%s\"}\n", return_data_str+2, gas_left_str);
         }
+        #endif
         delete[] gas_left_str;
         delete[] gas_cost_str;
         delete[] temp;

--- a/src/utils.cu
+++ b/src/utils.cu
@@ -61,7 +61,7 @@ __host__ void from_mpz(uint32_t *words, uint32_t count, mpz_t value) {
   size_t written;
 
   if(mpz_sizeinbase(value, 2)>count*32) {
-    fprintf(stderr, "from_mpz failed -- result does not fit\n");
+    fprintf(stdout, "from_mpz failed -- result does not fit\n");
     exit(1);
   }
 


### PR DESCRIPTION
### Fuzz test

In the [cassc/goemvlab](https://github.com/cassc/goevmlab) folder: 

```
# 1. Update the path to the evm binaries according to your system
# 2. Other than cuevm, one more evm is required to do the test
go run cmd/generic-fuzzer/main.go --revme binaries/revm --geth binaries/geth --cuevm binaries/cuevm
```

### Test without stateroot

Use the following sript to compare the call traces ignoring all `stateroot` and `CALL*` errors:

```python
# python runtests.py ~/projects/ethereum/tests/GeneralStateTests/Shanghai/
import os
import subprocess
import sys  # Import sys for exiting the script

# Set to true to auto generate the test cases instead of using the json files passed in
use_generic_fuzzer = 1

go_cmd = 'cmd/generic-fuzzer/main.go' if use_generic_fuzzer else 'cmd/runtest/main.go'


# base_command = ['go', 'run', go_cmd, '--revme=binaries/revm', '--cuevm=binaries/cuevm']
base_command = ['go', 'run', go_cmd, '--fork', 'Shanghai', '--geth=binaries/geth', '--cuevm=binaries/cuevm']

def test_cmd(full_command, retries=0):
    result = subprocess.run(full_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
    out = result.stdout.decode('utf-8')
    err = result.stderr.decode('utf-8')

    if 'error starting vm' in err:
        print("VM crashed 💥, ignore")
        # Uncomment these lines to exit when VM crashes
        # print(err)
        # sys.exit(1)

    if 'error' in out:
        if 'stateRoot' not in out and 'CALL' not in out: # ignore stateRoot mismatches
            print(out)
            if retries < 1:
                sys.exit(1)
                pass
            else:
                os.system('rm ./*.jsonl')
                test_cmd(full_command, retries-1)

if use_generic_fuzzer:
    print("Running generic fuzzer")
    while True:
        test_cmd(base_command)
else:
    root_dir = sys.argv[1]
    # Walk through all directories and files in the root directory
    for dirpath, dirnames, filenames in os.walk(root_dir):
        for filename in filenames:
            # Construct the full file path
            file_path = os.path.join(dirpath, filename)

            if not file_path.endswith('.json'):
                continue

            # Combine the base command with the current file path
            full_command = base_command + [file_path]

            print('Executing:', ' '.join(full_command))
            test_cmd(full_command, retries=0)

    print("All files have been processed.")
```

To reproduce a failed test case:

```
go run cmd/runtest/main.go --cuevm=binaries/cuevm --geth binaries/geth [replace-with-generated-input.json]
```

To view diffs of traces:

```
go run cmd/tracediff/main.go geth-0-output.jsonl cuevm-0-output.jsonl
```


# Issues found

### precompile contracts

We'll probably need to implment in cuevm, similar to what geth or revm do. @minhhn2910 @sdcioc any suggestions?

* [ ] [call-gas-mismatch.json](https://github.com/sbip-sg/CuEVM/files/14417258/call-gas-mismatch.json)

* [ ] [delegatecall-gas-mismatch.json](https://github.com/sbip-sg/CuEVM/files/14417268/delegatecall-gas-mismatch.json)


- [ ] [callcode-gas-mismatch.json](https://github.com/sbip-sg/CuEVM/files/14417327/callcode-gas-mismatch.json)



### CREATEx

- [ ] CREATE2 gas
   - [x]  [create2-gas.json](https://github.com/sbip-sg/CuEVM/files/14431842/create2-gas.json)
   - [ ] [CREATE2-TLOAD-gas.json](https://github.com/sbip-sg/CuEVM/files/14493527/CREATE2-TLOAD-gas.json)


- [x] CREATE gas  [CREATE-gas.json](https://github.com/sbip-sg/CuEVM/files/14442564/CREATE-gas.json)



### Other opcodes

- [x] SHR gas usage [SHR-gas.json](https://github.com/sbip-sg/CuEVM/files/14431943/SHR-gas.json)

- [x]  stack value after DIFFICULTY/PREVRANDAO (0x44) [DIFFICULTY.json](https://github.com/sbip-sg/CuEVM/files/14489911/CREATE-gas-2.json)

- [x] DELEGATECALL: the trace is different from PUSH31 after a DELEGATECALL, it could be caused by gas usage in DELEGATECALL [push31-gas.json](https://github.com/sbip-sg/CuEVM/files/14493388/push31-gas.json)

- [x] CALLCODE/RETURN: gas handling possibly calling non-existent address `0xf5` [CALLCODE-RETURN-gas.json](https://github.com/sbip-sg/CuEVM/files/14493480/CALLCODE-RETURN-gas.json)



### state root

need to pass necessary data using a format/protocol agreed on both goevmlab (by our implementation) and cuevm




